### PR TITLE
Position message actions menu

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -19,6 +19,7 @@ import * as flatpickr from "./flatpickr.ts";
 import * as hash_util from "./hash_util.ts";
 import * as hashchange from "./hashchange.ts";
 import * as message_edit from "./message_edit.ts";
+import * as message_actions_popover from "./message_actions_popover.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
 import * as message_view from "./message_view.ts";
@@ -90,6 +91,22 @@ export function initialize(): void {
 
         $("#main_div").on("contextmenu", ".messagebox", (e) => {
             e.preventDefault();
+            const selection = window.getSelection();
+            if (selection !== null && selection.toString().length > 0) {
+                return;
+            }
+            const $target = $(e.target as HTMLElement);
+            if ($target.closest("a, img").length > 0) {
+                return;
+            }
+
+            const $row = $(e.currentTarget).closest(".message_row");
+            const message_id = rows.id($row);
+            const message = message_lists.current?.get(message_id);
+            if (message === undefined) {
+                return;
+            }
+            message_actions_popover.toggle_message_actions_menu(message);
         });
     }
 

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -90,7 +90,6 @@ export function initialize(): void {
         });
 
         $("#main_div").on("contextmenu", ".messagebox", (e) => {
-            e.preventDefault();
             const selection = window.getSelection();
             if (selection !== null && selection.toString().length > 0) {
                 return;
@@ -99,6 +98,7 @@ export function initialize(): void {
             if ($target.closest("a, img").length > 0) {
                 return;
             }
+            e.preventDefault();
 
             const $row = $(e.currentTarget).closest(".message_row");
             const message_id = rows.id($row);


### PR DESCRIPTION
Fixes #38845

## What changed
This PR updates the message actions menu behavior when opening it via right-click.

Previously, the right-click handler opened the message actions menu, but the popover still appeared next to the three-dot message controls. With this change, the menu opens at the mouse position where the user right-clicked.

## How I tested it
- Ran Zulip locally.
- Opened a message in the development environment.
- Right-clicked on a message body.
- Confirmed that the message actions menu opens at the right-click position.
- Confirmed that the existing message actions menu behavior still works.

<img width="952" height="503" alt="image" src="https://github.com/user-attachments/assets/77d20f1f-a6a9-4250-8598-77c64442c5d6" />
